### PR TITLE
Docs: update zoom config

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ Set the zoomSelector (optional, defaults to '.markdown img') in `docusaurus.conf
   themeConfig: {
     zoom: {
       selector: '.markdown :not(em) > img',
-      // options you can specify via https://github.com/francoischalifour/medium-zoom#usage
       background: {
         light: 'rgb(255, 255, 255)',
         dark: 'rgb(50, 50, 50)'
-      }
-
+      },
+      // options you can specify via https://github.com/francoischalifour/medium-zoom#usage
+      config: {}
     }
   },
 ```

--- a/README.md
+++ b/README.md
@@ -24,13 +24,12 @@ Set the zoomSelector (optional, defaults to '.markdown img') in `docusaurus.conf
   themeConfig: {
     zoom: {
       selector: '.markdown :not(em) > img',
-      config: {
-        // options you can specify via https://github.com/francoischalifour/medium-zoom#usage
-        background: {
-          light: 'rgb(255, 255, 255)',
-          dark: 'rgb(50, 50, 50)'
-        }
+      // options you can specify via https://github.com/francoischalifour/medium-zoom#usage
+      background: {
+        light: 'rgb(255, 255, 255)',
+        dark: 'rgb(50, 50, 50)'
       }
+
     }
   },
 ```


### PR DESCRIPTION
According to the [code](https://github.com/gabrielcsapo/docusaurus-plugin-image-zoom/blob/main/src/zoom.js#L9) the background is not inside `zoom.config.background` but directly inside `zoom.background`. 