### PR TITLE
Removing types-only packages from peerDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,9 +24,7 @@
         "typescript": "^5.0.4"
       },
       "peerDependencies": {
-        "@docusaurus/module-type-aliases": ">=2.2.0",
-        "@docusaurus/theme-classic": ">=2.2.0",
-        "@docusaurus/types": ">=2.2.0"
+        "@docusaurus/theme-classic": ">=2.2.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -35,9 +35,7 @@
     "typescript": "^5.0.4"
   },
   "peerDependencies": {
-    "@docusaurus/module-type-aliases": ">=2.2.0",
-    "@docusaurus/theme-classic": ">=2.2.0",
-    "@docusaurus/types": ">=2.2.0"
+    "@docusaurus/theme-classic": ">=2.2.0"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"


### PR DESCRIPTION
## Summary

This PR removes the types-only packages that were incorrectly included in `peerDependencies`.
