### PR TITLE
fix: Remove unnecessary files from publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,10 @@ node_modules
 yarn-error.log
 /dist
 lib/
-.yarn
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions

--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,0 @@
-website/
-.github/
-.vscode/
-.prettierrc.cjs
-tsconfig.json

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
   "author": "Gabriel J. Csapo <gabecsapo@gmail.com>",
   "type": "module",
   "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "build": "tsc",
     "prepublishOnly": "npm run build",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "types": ["node", "@docusaurus/module-type-aliases", "@docusaurus/theme-classic"],
     "outDir": "lib",
-    "noEmit": false
+    "noEmit": false,
+    "declaration": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["**/node_modules/**"]


### PR DESCRIPTION
Hi @gabrielcsapo,

currently npm publishes the following files when releasing:

name | type | size
-- | -- | --
.yarn/ | folder | 1.39 MB
lib/ | folder | 1.78 kB
src/ | folder | 1.91 kB
.yarnrc.yml | text/yaml | 25 B
CHANGELOG.md | text/markdown | 3.85 kB
LICENSE | text/plain | 1.07 kB
README.md | text/markdown | 2.41 kB
RELEASE.md | text/markdown | 2.19 kB
package.json | application/json | 1.71 kB

(see https://www.npmjs.com/package/docusaurus-plugin-image-zoom?activeTab=code)

The `.yarn` directory even includes a yarn install state, which is irrelevant for other users and is 1.39 MB in size!

This PR will:
- let git ignore all irrelevant yarn files
- let npm ignore all irrelevant files for publishing
- let TypeScript create declaration files to help users use this plugin with TypeScript (there is no need to publish the TypeScript source files)

Afterwards, only these files will be published:

name | type | size
-- | -- | --
lib/ | folder | 1.78 kB
LICENSE | text/plain | 1.07 kB
README.md | text/markdown | 2.41 kB
package.json | application/json | 1.71 kB